### PR TITLE
Add different command to run minikube on Windows

### DIFF
--- a/kubernetes-setup.adoc
+++ b/kubernetes-setup.adoc
@@ -7,10 +7,18 @@ Minikube::
 --	
 Having `minikube` installed and in your `PATH`, then run:
 
+**MacOS / Linux:**
 [.console-input]
 [source,bash,subs="attributes+,+macros"]	
 ----	
 minikube start --memory=8192 --cpus=3 --kubernetes-version={kubernetes-version} --vm-driver=virtualbox -p {profile}	
+----	
+
+**Windows:**
+[.console-input]
+[source,bash,subs="attributes+,+macros"]	
+----	
+minikube start --memory=8192 --cpus=3 --kubernetes-version={kubernetes-version} --vm-driver=hyperv -p {profile}	
 ----	
 
 And the output must be something similar like:	


### PR DESCRIPTION
A colleague of mine and I were struggling for hours to get minikube to run on Windows using the provided command.
We received a lot of errors about some Linux commands not being able to be executed (not really surprising given it's a Windows machine 😄 ).

We tried a lot of things, but in the end the only thing that helped was using the `hyperv` driver by replacing `--vm-driver=virtualbox` by `--vm-driver=hyperv`. From then on, everything worked smoothly without any issues.

Given that `hyperv` is also a preferred driver as recommended by minikube (while `virtualbox` is NOT, see https://minikube.sigs.k8s.io/docs/drivers/) I would suggest to specify a different command for Windows to make sure that people don't run into the same issues that we did.