### PR TITLE
Bump Linux stern version to 1.11.0

### DIFF
--- a/prerequisites-kubernetes.adoc
+++ b/prerequisites-kubernetes.adoc
@@ -34,7 +34,7 @@ Please have them installed and configured before you get started with any of the
 
 | https://github.com/wercker/stern[stern]
 | `brew install stern`
-| https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64[Download]
+| https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64[Download]
 | https://github.com/wercker/stern/releases/download/1.11.0/stern_windows_amd64.exe[Download]
 
 | `Apache Maven {maven-version}`


### PR DESCRIPTION
1.6.0 with OpenShift 4.6 is throwing a parse exception.

That might be an oversight as the Windows version was already bumped.